### PR TITLE
Remove settings from Sender constructor argument

### DIFF
--- a/examples/main/src/sender.mo
+++ b/examples/main/src/sender.mo
@@ -30,11 +30,7 @@ actor class Sender(receiverId : Principal) {
     await receiver.receive(message);
   };
 
-  let sender = Stream.StreamSender<Text, ?Text>(
-    send,
-    counter,
-    null
-  );
+  let sender = Stream.StreamSender<Text, ?Text>(send, counter);
 
   public shared func add(text : Text) : async () {
     Result.assertOk(sender.push(text));

--- a/examples/minimal/src/alice.mo
+++ b/examples/minimal/src/alice.mo
@@ -24,7 +24,7 @@ actor class Main(receiver : Principal) {
       return ?item;
     };
   };
-  let sender = Stream.StreamSender<Item, Item>(send_, counter_, null);
+  let sender = Stream.StreamSender<Item, Item>(send_, counter_);
 
   // example use of sender `push` and `sendChunk`
   public shared func enqueue(n : Nat) : async () {

--- a/examples/promtracker/src/sender.mo
+++ b/examples/promtracker/src/sender.mo
@@ -38,7 +38,6 @@ actor class Sender(receiverId : Principal) = self {
   let sender = Stream.StreamSender<Text, ?Text>(
     func(x : ChunkMessage) : async* ControlMessage { await receiver.receive(x) },
     counter,
-    null,
   );
 
   sender.setKeepAlive(?(10 ** 15, Time.now));

--- a/src/StreamSender.mo
+++ b/src/StreamSender.mo
@@ -20,10 +20,10 @@ module {
   public let MAX_CONCURRENT_CHUNKS_DEFAULT = 5;
 
   /// Settings of `StreamSender`.
-  public type SettingsArg = {
-    maxQueueSize : ?Nat;
-    windowSize : ?Nat;
-    keepAlive : ?(Nat, () -> Int);
+  public type Settings = {
+    var maxQueueSize : ?Nat;
+    var windowSize : Nat;
+    var keepAlive : ?(Nat, () -> Int);
   };
 
   /// Type of `StableData` for `share`/`unshare` function.
@@ -58,7 +58,6 @@ module {
   public class StreamSender<Q, S>(
     sendFunc : (x : Types.ChunkMessage<S>) -> async* Types.ControlMessage,
     counterCreator : () -> { accept(item : Q) : ?S },
-    settings : ?SettingsArg,
   ) {
     public var callbacks : Callbacks = {
       onNoSend = func(_) {};
@@ -70,13 +69,10 @@ module {
 
     let buffer = SWB.SlidingWindowBuffer<Q>();
 
-    let settings_ = {
-      var maxQueueSize = Option.chain<SettingsArg, Nat>(settings, func(s) = s.maxQueueSize);
-      var keepAlive = Option.chain<SettingsArg, (Nat, () -> Int)> (settings, func(s) = s.keepAlive);
-      var windowSize : Nat = Option.get(
-        Option.chain<SettingsArg, Nat>(settings, func(s) = s.windowSize),
-        MAX_CONCURRENT_CHUNKS_DEFAULT,
-      );
+    let settings_ : Settings = {
+      var maxQueueSize = null;
+      var keepAlive = null;
+      var windowSize = MAX_CONCURRENT_CHUNKS_DEFAULT
     };
     public func maxQueueSize() : ?Nat = settings_.maxQueueSize;
     public func windowSize() : Nat = settings_.windowSize;

--- a/test/actors.test.mo
+++ b/test/actors.test.mo
@@ -153,11 +153,7 @@ actor A {
     };
   };
 
-  let sender = StreamSender.StreamSender<Text, ?Text>(
-    sendToReceiver,
-    counter,
-    null,
-  );
+  let sender = StreamSender.StreamSender<Text, ?Text>(sendToReceiver, counter);
 
   public func submit(item : Text) : async { #err : { #NoSpace }; #ok : Nat } {
     let res = sender.push(item);

--- a/test/main.test.mo
+++ b/test/main.test.mo
@@ -47,11 +47,7 @@ func createSender(receiver : Receiver<?Text>) : Sender<Text, ?Text> {
 
   func send(ch : ChunkMessage) : async* ControlMessage { receiver.onChunk(ch) };
 
-  let sender = Sender<Text, ?Text>(
-    send,
-    counter,
-    null,
-  );
+  let sender = Sender<Text, ?Text>(send, counter);
   sender;
 };
 

--- a/test/restart.test.mo
+++ b/test/restart.test.mo
@@ -33,11 +33,7 @@ func createReceiver() : Receiver<?Text> {
 func createSender(receiver : Receiver<?Text>) : Sender<Text, ?Text> {
   func send(ch : ChunkMessage) : async* ControlMessage { receiver.onChunk(ch) };
 
-  let sender = Sender<Text, ?Text>(
-    send,
-    Base.create(1),
-    null,
-  );
+  let sender = Sender<Text, ?Text>(send, Base.create(1));
   sender;
 };
 

--- a/test/sender.concurrent.test.mo
+++ b/test/sender.concurrent.test.mo
@@ -54,13 +54,9 @@ class Sender(n : Nat) {
 
   let sender = StreamSender.StreamSender<Text, ?Text>(
     sendChunkMessage,
-    Base.create(1),
-    ?{
-      keepAlive = ?(1, func() = time);
-      maxQueueSize = null;
-      windowSize = null;
-    },
+    Base.create(1)
   );
+  sender.setKeepAlive(?(1, func() = time));
 
   public func send(chunk : Chunk) : async () {
     chunkRegister := chunk;

--- a/test/sender.test.mo
+++ b/test/sender.test.mo
@@ -24,7 +24,6 @@ do {
   let sender = StreamSender.StreamSender<Text, ?Text>(
     send,
     Base.create(5),
-    null,
   );
 
   for (i in Iter.range(0, N - 1)) {
@@ -54,7 +53,6 @@ do {
   let sender = StreamSender.StreamSender<Text, ?Text>(
     send,
     Base.create(6),
-    null,
   );
 
   for (i in Iter.range(0, N - 1)) {
@@ -78,7 +76,6 @@ do {
   let sender = StreamSender.StreamSender<Text, ?Text>(
     send,
     Base.create(5),
-    null,
   );
   Result.assertOk(sender.push("abc"));
   await* sender.sendChunk();
@@ -94,7 +91,6 @@ do {
   let sender = StreamSender.StreamSender<Text, ?Text>(
     send,
     Base.create(5),
-    null,
   );
   Result.assertOk(sender.push("abc"));
   assert sender.status() == #ready;


### PR DESCRIPTION
We have setter functions which we already use in examples/tests. They are more convenient than this argument.