### PR TITLE
Stop with partial batches

### DIFF
--- a/.github/workflows/pull_request_build.yml
+++ b/.github/workflows/pull_request_build.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   mops_version: latest
-  dfx_version: 0.15.2
+  dfx_version: 0.15.3
 
 jobs:
   build:

--- a/examples/main/src/receiver.mo
+++ b/examples/main/src/receiver.mo
@@ -9,9 +9,9 @@ actor Receiver {
   let received = Buffer.Buffer<?Text>(0);
 
   let receiver = Stream.StreamReceiver<?Text>(
-    func(index : Nat, item : ?Text) {
-      assert received.size() == index;
+    func(index : Nat, item : ?Text) : Bool {
       received.add(item);
+      received.size() == index + 1;
     },
     null,
   );

--- a/examples/minimal/src/bob.mo
+++ b/examples/minimal/src/bob.mo
@@ -7,13 +7,14 @@ actor class Main(sender : Principal) {
 
   // define your processing function
   var log_ : Text = "";
-  func processItem(index : Nat, item : Item) : () {
+  func processItem(index : Nat, item : Item) : Bool {
     // choose function name, keep the signature
     log_ #= debug_show (index, item) # " "; // put your processing code here
+    true;
   };
 
   // begin boilerplate
-  let receiver_ = Stream.StreamReceiver<Item>(processItem, null); // substitute your processing function for `processItem` 
+  let receiver_ = Stream.StreamReceiver<Item>(processItem, null); // substitute your processing function for `processItem`
   public shared (msg) func receive(m : Stream.ChunkMessage<Item>) : async Stream.ControlMessage {
     // choose a name for public endpoint `receive`
     if (msg.caller != sender) throw Error.reject("not authorized"); // use the init argument `sender` here

--- a/examples/promtracker/src/receiver.mo
+++ b/examples/promtracker/src/receiver.mo
@@ -14,7 +14,7 @@ actor class Receiver() = self {
   public func lastReceived() : async ?Text { store };
 
   let receiver = Stream.StreamReceiver<?Text>(
-    func(_ : Nat, item : ?Text) = store := item,
+    func(_ : Nat, item : ?Text) : Bool { store := item; true },
     ?(10 ** 15, Time.now),
   );
 

--- a/mops.toml
+++ b/mops.toml
@@ -7,7 +7,7 @@ keywords = [ "stream sender", "stream receiver", "streams" ]
 license = "Apache-2.0"
 
 [dependencies]
-base = "0.10.3"
+base = "0.10.4"
 swb = "1.1.1"
 vector = "0.2.0"
 promtracker = "0.4.0"
@@ -16,4 +16,4 @@ promtracker = "0.4.0"
 test = "1.2.0"
 
 [toolchain]
-moc = "0.10.3"
+moc = "0.10.4"

--- a/src/StreamReceiver.mo
+++ b/src/StreamReceiver.mo
@@ -90,7 +90,7 @@ module {
       switch (msg) {
         case (#ping or #chunk _) {
           checkTimeAndStop();
-          if (stopped_) return #stop;
+          if (stopped_) return #stop 0;
         };
         case (#restart) {
           resetTimeout();
@@ -100,7 +100,7 @@ module {
       let #chunk ch = msg else return #ok;
       switch (maxLength) {
         case (?l) {
-          if (ch.size() + length_ > l) return #stop;
+          if (ch.size() + length_ > l) return #stop 0;
         };
         case (null) {};
       };

--- a/src/StreamReceiver.mo
+++ b/src/StreamReceiver.mo
@@ -26,7 +26,7 @@ module {
   /// * `itemCallback` function
   /// * `timeout` is maximum waiting time between onChunk calls (default = infinite)
   public class StreamReceiver<T>(
-    itemCallback : (pos : Nat, item : T) -> (),
+    itemCallback : (pos : Nat, item : T) -> (Bool),
     timeoutArg : ?(Nat, () -> Int),
   ) {
     /// Callbacks called during processing chunk.
@@ -104,9 +104,16 @@ module {
         };
         case (null) {};
       };
-      for (i in ch.keys()) itemCallback(start + i, ch[i]);
-      length_ += ch.size();
-      return #ok;
+      var i = 0;
+      label w while (i < ch.size()) {
+        if (not itemCallback(start + i, ch[i])) break w;
+        i += 1;
+      };
+      length_ += i;
+      if (i == ch.size()) #ok else #stop i;
+//      for (i in ch.keys()) itemCallback(start + i, ch[i]);
+//      length_ += ch.size();
+//      return #ok;
     };
 
     /// Manually stop the receiver.

--- a/src/StreamReceiver.mo
+++ b/src/StreamReceiver.mo
@@ -1,3 +1,4 @@
+import Nat "mo:base/Nat";
 import SWB "mo:swb";
 import Types "types";
 
@@ -98,22 +99,17 @@ module {
         };
       };
       let #chunk ch = msg else return #ok;
-      switch (maxLength) {
-        case (?l) {
-          if (ch.size() + length_ > l) return #stop 0;
-        };
-        case (null) {};
+      let n = switch (maxLength) {
+        case (?max) Nat.min(max - length_, ch.size());
+        case (null) ch.size();
       };
       var i = 0;
-      label w while (i < ch.size()) {
+      label w while (i < n) {
         if (not itemCallback(start + i, ch[i])) break w;
         i += 1;
       };
       length_ += i;
       if (i == ch.size()) #ok else #stop i;
-//      for (i in ch.keys()) itemCallback(start + i, ch[i]);
-//      length_ += ch.size();
-//      return #ok;
     };
 
     /// Manually stop the receiver.

--- a/src/StreamReceiver.mo
+++ b/src/StreamReceiver.mo
@@ -27,7 +27,7 @@ module {
   /// * `itemCallback` function
   /// * `timeout` is maximum waiting time between onChunk calls (default = infinite)
   public class StreamReceiver<T>(
-    itemCallback : (pos : Nat, item : T) -> (Bool),
+    itemCallback : (pos : Nat, item : T) -> Bool,
     timeoutArg : ?(Nat, () -> Int),
   ) {
     /// Callbacks called during processing chunk.

--- a/src/StreamSender.mo
+++ b/src/StreamSender.mo
@@ -200,7 +200,7 @@ module {
       updateTime();
       concurrentChunks += 1;
 
-      callbacks.onSend(Types.info(chunkPayload));
+      callbacks.onSend(Types.chunkInfo(chunkPayload));
 
       let res = try {
         await* sendFunc((start, chunkPayload));
@@ -234,7 +234,7 @@ module {
       switch (res) {
         case (#ok) okTo := end;
         case (#gap) { retraceTo := start; retraceMoreLater := true };
-        case (#stop) { okTo := start; retraceTo := start };
+        case (#stop l) { okTo := start + l; retraceTo := start + l };
         case (#error) if (start != end) retraceTo := start;
       };
 
@@ -262,7 +262,10 @@ module {
       if (concurrentChunks == 0) paused := false;
 
       // stop stream
-      if (res == #stop) stopped := true;
+      switch (res) {
+        case (#stop _) stopped := true;
+        case (_) {};
+      };
 
       callbacks.onResponse(res);
     };

--- a/src/Tracker.mo
+++ b/src/Tracker.mo
@@ -80,10 +80,10 @@ module {
           lastRestartPos.set(pos);
         };
         case (_, #gap) gaps.add(1);
-        case (_, #stop) {
+        case (_, #stop i) {
           stops.add(1);
           stopFlag.update(1);
-          lastStopPos.set(pos);
+          lastStopPos.set(pos + i);
         };
       };
       let now = Prim.nat64ToNat(Prim.time() / 10 ** 6);
@@ -206,11 +206,11 @@ module {
       chunkErrorType.update(rejectCode);
     };
 
-    public func onResponse(res : { #ok; #gap; #stop; #error }) {
+    public func onResponse(res : Types.ControlMessage or { #error }) {
       switch (res) {
         case (#ok) oks.add(1);
         case (#gap) gaps.add(1);
-        case (#stop) stops.add(1);
+        case (#stop _) stops.add(1);
         case (#error) errors.add(1);
       };
       let ?s = sender_ else return;

--- a/src/types.mo
+++ b/src/types.mo
@@ -1,23 +1,17 @@
 module {
-  /// Type of messages sent to the receiver
-  public type ChunkMessage<T> = (
-    pos : Nat,
-    {
-      #chunk : [T];
-      #ping;
-      #restart;
-    },
-  );
+  public type ChunkPayload<T> = { #chunk : [T]; #ping };
+  public type ChunkInfo = { #chunk : Nat; #ping };
+  public func chunkInfo(m : ChunkPayload<Any>) : ChunkInfo {
+    switch m {
+      case (#chunk c) #chunk(c.size());
+      case (#ping) #ping;
+    };
+  };
 
-  public type ChunkMessageInfo = (
-    pos : Nat,
-    {
-      #chunk : Nat;
-      #ping;
-      #restart;
-    },
-  );
-  
+  /// Type of messages sent to the receiver
+  /// (stream position, chunk payload)
+  public type ChunkMessage<T> = (Nat, ChunkPayload<T> or { #restart });
+  public type ChunkMessageInfo = (Nat, ChunkInfo or { #restart });
   public func chunkMessageInfo(m : ChunkMessage<Any>) : ChunkMessageInfo {
     (
       m.0,
@@ -29,24 +23,6 @@ module {
     );
   };
 
-  public type ChunkPayload<T> = {
-    #chunk : [T];
-    #ping;
-  };
-
-  /// Information passed to callback
-  public type ChunkInfo = {
-    #chunk : Nat;
-    #ping;
-  };
-
-  public func info(m : ChunkPayload<Any>) : ChunkInfo {
-    switch m {
-      case (#chunk c) #chunk(c.size());
-      case (#ping) #ping;
-    };
-  };
-
   /// Return type of processing function.
-  public type ControlMessage = { #ok; #gap; #stop };
+  public type ControlMessage = { #ok; #gap; #stop : Nat };
 };

--- a/test/actors.test.mo
+++ b/test/actors.test.mo
@@ -56,12 +56,12 @@ actor B {
         Debug.print(str # "reject");
         throw Error.reject("failMode");
       };
-      case (#stop) #stop;
+      case (#stop) #stop 0;
     };
     switch (res) {
       case (#ok) str #= "#ok";
       case (#gap) str #= "#gap"; 
-      case (#stop) str #= "#stop";
+      case (#stop _) str #= "#stop";
     };
     Debug.print(str);
     res;
@@ -137,7 +137,7 @@ actor A {
       switch (ret) {
         case (#ok) str #= "ok";
         case (#gap) str #= "gap";
-        case (#stop) str #= "stop";
+        case (#stop _) str #= "stop";
       };
       Debug.print(str);
       return ret;

--- a/test/actors.test.mo
+++ b/test/actors.test.mo
@@ -16,7 +16,7 @@ type ControlMessage = Types.ControlMessage;
 actor B {
   // processor of received items
   let received = Buffer.Buffer<Text>(0);
-  func processItem(i : Nat, item : ?Text) {
+  func processItem(i : Nat, item : ?Text) : Bool {
     let prefix = ".   B   item " # Nat.toText(i) # ": ";
     switch (item) {
       case (null) Debug.print(prefix # "null");
@@ -25,6 +25,7 @@ actor B {
         received.add(x);
       };
     };
+    true;
   };
 
   // StreamReceiver
@@ -60,7 +61,7 @@ actor B {
     };
     switch (res) {
       case (#ok) str #= "#ok";
-      case (#gap) str #= "#gap"; 
+      case (#gap) str #= "#gap";
       case (#stop _) str #= "#stop";
     };
     Debug.print(str);
@@ -155,7 +156,10 @@ actor A {
 
   let sender = StreamSender.StreamSender<Text, ?Text>(sendToReceiver, counter);
 
-  public func submit(item : Text) : async { #err : { #NoSpace; #LimitExceeded }; #ok : Nat } {
+  public func submit(item : Text) : async {
+    #err : { #NoSpace; #LimitExceeded };
+    #ok : Nat;
+  } {
     let res = sender.push(item);
     var str = "A submit: ";
     switch (res) {
@@ -176,13 +180,10 @@ actor A {
   };
 
   public query func isState(l : [Nat]) : async Bool {
-    Debug.print("A isState: " # debug_show(l));
-    sender.length() == l[0] and
-    sender.sent() == l[1] and
-    sender.received() == l[2] and
-    sender.busyLevel() == l[3];
+    Debug.print("A isState: " # debug_show (l));
+    sender.length() == l[0] and sender.sent() == l[1] and sender.received() == l[2] and sender.busyLevel() == l[3];
   };
-  
+
   public query func isShutdown() : async Bool {
     sender.isShutdown();
   };
@@ -196,28 +197,28 @@ assert ((await A.submit("m2xxx")) == #ok 2);
 assert ((await A.submit("m3-long")) == #ok 3);
 assert ((await A.submit("m4-long")) == #ok 4);
 assert ((await A.submit("m5")) == #ok 5);
-assert await A.isState([6,0,0,0]);
+assert await A.isState([6, 0, 0, 0]);
 assert ((await B.nReceived()) == 0);
 ignore A.trigger(); // chunk m0, m1
-assert await A.isState([6,2,0,1]); // chunk was sent 
-assert await A.isState([6,2,2,0]); // chunk has returned ok
+assert await A.isState([6, 2, 0, 1]); // chunk was sent
+assert await A.isState([6, 2, 2, 0]); // chunk has returned ok
 assert ((await B.nReceived()) == 2);
 await B.setFailMode(#reject, 0);
 ignore A.trigger(); // chunk m2,null,null will fail
-assert await A.isState([6,5,2,1]); // chunk was sent 
-assert await A.isState([6,2,2,0]); // chunk has returned rejected
+assert await A.isState([6, 5, 2, 1]); // chunk was sent
+assert await A.isState([6, 2, 2, 0]); // chunk has returned rejected
 ignore A.trigger(); // chunk m2,null,null will fail
-assert await A.isState([6,5,2,1]); // chunk was sent 
-assert await A.isState([6,2,2,0]); // chunk has returned rejected
+assert await A.isState([6, 5, 2, 1]); // chunk was sent
+assert await A.isState([6, 2, 2, 0]); // chunk has returned rejected
 assert ((await B.nReceived()) == 2);
 await B.setFailMode(#off, 0);
 ignore A.trigger(); // chunk m2,null,null will succeed
-assert await A.isState([6,5,2,1]); // chunk was sent 
-assert await A.isState([6,5,5,0]); // chunk has returned ok
+assert await A.isState([6, 5, 2, 1]); // chunk was sent
+assert await A.isState([6, 5, 5, 0]); // chunk has returned ok
 assert ((await B.nReceived()) == 3);
 ignore A.trigger(); // chunk m5
-assert await A.isState([6,6,5,1]); // chunk was sent 
-assert await A.isState([6,6,6,0]); // chunk has returned ok
+assert await A.isState([6, 6, 5, 1]); // chunk was sent
+assert await A.isState([6, 6, 6, 0]); // chunk has returned ok
 assert ((await B.nReceived()) == 4);
 await A.trigger(); // no items left
 assert ((await B.nReceived()) == 4);
@@ -231,14 +232,14 @@ assert (list[3] == "m5");
 Debug.print("=== Part 2 ===");
 assert ((await A.submit("m6xxx")) == #ok 6);
 assert ((await A.submit("m7xxx")) == #ok 7);
-assert await A.isState([8,6,6,0]);
+assert await A.isState([8, 6, 6, 0]);
 ignore A.trigger();
-let a1 = A.isState([8,7,6,1]);
+let a1 = A.isState([8, 7, 6, 1]);
 ignore A.trigger();
-let a2 = A.isState([8,8,6,2]);
+let a2 = A.isState([8, 8, 6, 2]);
 await async {};
 // here the two chunks have returned with ok
-let a3 = A.isState([8,8,8,0]);
+let a3 = A.isState([8, 8, 8, 0]);
 await async {};
 assert await a1;
 assert await a2;
@@ -250,22 +251,22 @@ assert ((await A.submit("m8")) == #ok 8);
 assert ((await A.submit("m9")) == #ok 9);
 assert ((await A.submit("mA")) == #ok 10);
 assert ((await A.submit("mB")) == #ok 11);
-assert await A.isState([12,8,8,0]);
+assert await A.isState([12, 8, 8, 0]);
 ignore B.setFailMode(#reject, 0);
 ignore A.trigger();
-let b1 = A.isState([12,10,8,1]);
+let b1 = A.isState([12, 10, 8, 1]);
 ignore B.setFailMode(#off, 1);
 ignore A.trigger();
-let b2 = A.isState([12,12,8,2]);
+let b2 = A.isState([12, 12, 8, 2]);
 await async {};
 // here the two chunks have returned with rejects
-let b3 = A.isState([12,8,8,0]);
+let b3 = A.isState([12, 8, 8, 0]);
 assert await b1;
 assert await b2;
 assert await b3;
 ignore A.trigger();
 ignore A.trigger();
 await async {};
-assert await A.isState([12,12,12,0]);
- 
+assert await A.isState([12, 12, 12, 0]);
+
 assert not (await A.isShutdown());

--- a/test/main.test.mo
+++ b/test/main.test.mo
@@ -18,9 +18,10 @@ func createReceiver() : Receiver<?Text> {
   let received = Buffer.Buffer<?Text>(0);
 
   let receiver = Receiver<?Text>(
-    func(pos : Nat, item : ?Text) {
+    func(pos : Nat, item : ?Text) : Bool {
       assert pos == received.size();
       received.add(item);
+      true;
     },
     null,
   );

--- a/test/main.test.mo
+++ b/test/main.test.mo
@@ -19,9 +19,8 @@ func createReceiver() : Receiver<?Text> {
 
   let receiver = Receiver<?Text>(
     func(pos : Nat, item : ?Text) : Bool {
-      assert pos == received.size();
       received.add(item);
-      true;
+      received.size() == pos + 1;
     },
     null,
   );

--- a/test/main.test.mo
+++ b/test/main.test.mo
@@ -7,6 +7,7 @@ import Error "mo:base/Error";
 import Time "mo:base/Time";
 import Debug "mo:base/Debug";
 import Nat "mo:base/Nat";
+import Result "mo:base/Result";
 import Types "../src/types";
 
 type ChunkMessage = Types.ChunkMessage<?Text>;
@@ -51,26 +52,54 @@ func createSender(receiver : Receiver<?Text>) : Sender<Text, ?Text> {
   sender;
 };
 
-let receiver = createReceiver();
-let sender = createSender(receiver);
+do {
+  let receiver = createReceiver();
+  let sender = createSender(receiver);
 
-ignore sender.push("abc");
-ignore sender.push("abcdef");
-ignore sender.push("abc");
-ignore sender.push("def");
-ignore sender.push("get");
-ignore sender.push("nmb");
-ignore sender.push("abc");
-ignore sender.push("abc");
-ignore sender.push("abc");
+  ignore sender.push("abc");
+  ignore sender.push("abcdef");
+  ignore sender.push("abc");
+  ignore sender.push("def");
+  ignore sender.push("get");
+  ignore sender.push("nmb");
+  ignore sender.push("abc");
+  ignore sender.push("abc");
+  ignore sender.push("abc");
 
-let n = sender.length();
+  let n = sender.length();
 
-var i = 0;
-let max = 100;
-while (sender.received() < n and i < max) {
-  await* sender.sendChunk();
-  i += 1;
+  var i = 0;
+  let max = 100;
+  while (sender.received() < n and i < max) {
+    await* sender.sendChunk();
+    i += 1;
+  };
+  Debug.print("sent " # Nat.toText(i) # " chunks");
+  assert i != max;
 };
-Debug.print("sent " # Nat.toText(i) # " chunks");
-assert i != max;
+
+do {
+  let receiver = createReceiver();
+  let sender = createSender(receiver);
+
+  let MAX_LENGTH = 3;
+  receiver.setMaxLength(?MAX_LENGTH);
+  sender.setMaxStreamLength(?(MAX_LENGTH + MAX_LENGTH));
+
+  Result.assertOk(sender.push("abc"));
+  Result.assertOk(sender.push("abcde"));
+  Result.assertOk(sender.push("ac"));
+  Result.assertOk(sender.push("abc"));
+  Result.assertOk(sender.push("abcde"));
+  Result.assertOk(sender.push("ac"));
+  Result.assertErr(sender.push("d"));
+
+  var i = 0;
+  let max = 100;
+  while (sender.status() == #ready and i < max) {
+    await* sender.sendChunk();
+    i += 1;
+  };
+
+  assert receiver.length() == MAX_LENGTH;
+};

--- a/test/receiver.test.mo
+++ b/test/receiver.test.mo
@@ -5,9 +5,8 @@ import StreamReceiver "../src/StreamReceiver";
 do {
   var size = 0;
   func process(index : Nat, item : Text) : Bool {
-    assert size == index;
     size += 1;
-    true;
+    size == index + 1;
   };
 
   let receiver = StreamReceiver.StreamReceiver<Text>(process, null);
@@ -28,9 +27,8 @@ do {
 do {
   var size = 0;
   func process(index : Nat, item : Text) : Bool {
-    assert size == index;
     size += 1;
-    true;
+    size == index + 1;
   };
 
   var time = 0;

--- a/test/receiver.test.mo
+++ b/test/receiver.test.mo
@@ -4,9 +4,10 @@ import StreamReceiver "../src/StreamReceiver";
 // test index counter and gap detection
 do {
   var size = 0;
-  func process(index : Nat, item : Text) {
+  func process(index : Nat, item : Text) : Bool {
     assert size == index;
     size += 1;
+    true;
   };
 
   let receiver = StreamReceiver.StreamReceiver<Text>(process, null);
@@ -26,9 +27,10 @@ do {
 // test timeout detection
 do {
   var size = 0;
-  func process(index : Nat, item : Text) {
+  func process(index : Nat, item : Text) : Bool {
     assert size == index;
     size += 1;
+    true;
   };
 
   var time = 0;

--- a/test/receiver.test.mo
+++ b/test/receiver.test.mo
@@ -48,5 +48,5 @@ do {
   assert receiver.lastChunkReceived() == 2;
 
   time := 4;
-  assert receiver.onChunk((2, #chunk(["abc"]))) == #stop;
+  assert receiver.onChunk((2, #chunk(["abc"]))) == #stop 0;
 };

--- a/test/restart.test.mo
+++ b/test/restart.test.mo
@@ -24,6 +24,7 @@ func createReceiver() : Receiver<?Text> {
     func(pos : Nat, item : ?Text) {
       assert pos == received.size();
       received.add(item);
+      true;
     },
     null,
   );

--- a/test/restart.test.mo
+++ b/test/restart.test.mo
@@ -22,9 +22,8 @@ func createReceiver() : Receiver<?Text> {
 
   let receiver = Receiver<?Text>(
     func(pos : Nat, item : ?Text) {
-      assert pos == received.size();
       received.add(item);
-      true;
+      received.size() == pos + 1;
     },
     null,
   );

--- a/test/sender.concurrent.test.mo
+++ b/test/sender.concurrent.test.mo
@@ -11,10 +11,11 @@ import Random "mo:base/Random";
 import Option "mo:base/Option";
 import Base "sender.base";
 import StreamReceiver "../src/StreamReceiver";
+import Types "../src/types";
 // Note: A chunk response of #trap (aka canister_error) cannot be simulated with
 // the moc interpreter. Calling Debug.trap() to generate the error would
 // instantly terminate the whole test.
-type ChunkResponse = { #ok; #gap; #stop; #error };
+type ChunkResponse = Types.ControlMessage or { #error };
 
 class Chunk() {
   var response : ?ChunkResponse = null;
@@ -24,7 +25,7 @@ class Chunk() {
     switch (response) {
       case (? #ok) #ok;
       case (? #gap) #gap;
-      case (? #stop) #stop;
+      case (? #stop n) #stop n;
       case (? #error) throw Error.reject("");
       case (null) Debug.trap("cannot happen");
     };
@@ -345,7 +346,7 @@ do {
     (#ok, #ready, 1, 1),
     (#gap, #shutdown, 0, 0),
     (#error, #ready, 0, 0),
-    (#stop, #stopped, 0, 0),
+    (#stop 0, #stopped, 0, 0),
   ];
   for (t in tests.vals()) {
     let (response, status, pos, sent) = t;
@@ -359,12 +360,12 @@ do {
     (#ok, #shutdown, 2, 0),
     (#gap, #stopped, 0, 0),
     (#error, #stopped, 0, 0),
-    (#stop, #shutdown, 1, 0),
+    (#stop 0, #shutdown, 1, 0),
   ];
   for (t in tests.vals()) {
     let (response, status, pos, sent) = t;
     await test([
-      (0, #stop, #stopped, 0, 0),
+      (0, #stop 0, #stopped, 0, 0),
       (1, response, status, pos, sent),
     ]);
   };
@@ -376,22 +377,22 @@ do {
     ([#ok, #ok], [(#ready, 1, 2), (#ready, 2, 2)]),
     ([#ok, #gap], [(#ready, 1, 2), (#shutdown, 1, 1)]),
     ([#ok, #error], [(#ready, 1, 2), (#ready, 1, 1)]),
-    ([#ok, #stop], [(#ready, 1, 2), (#stopped, 1, 1)]),
+    ([#ok, #stop 0], [(#ready, 1, 2), (#stopped, 1, 1)]),
 
     ([#gap, #ok], [(#shutdown, 0, 0), (#shutdown, 2, 0)]),
     ([#gap, #gap], [(#shutdown, 0, 0), (#shutdown, 0, 0)]),
     ([#gap, #error], [(#shutdown, 0, 0), (#shutdown, 0, 0)]),
-    ([#gap, #stop], [(#shutdown, 0, 0), (#shutdown, 1, 0)]),
+    ([#gap, #stop 0], [(#shutdown, 0, 0), (#shutdown, 1, 0)]),
 
     ([#error, #ok], [(#paused, 0, 0), (#shutdown, 2, 0)]),
     ([#error, #gap], [(#paused, 0, 0), (#ready, 0, 0)]),
     ([#error, #error], [(#paused, 0, 0), (#ready, 0, 0)]),
-    ([#error, #stop], [(#paused, 0, 0), (#shutdown, 1, 0)]),
+    ([#error, #stop 0], [(#paused, 0, 0), (#shutdown, 1, 0)]),
 
-    ([#stop, #ok], [(#stopped, 0, 0), (#shutdown, 2, 0)]),
-    ([#stop, #gap], [(#stopped, 0, 0), (#stopped, 0, 0)]),
-    ([#stop, #error], [(#stopped, 0, 0), (#stopped, 0, 0)]),
-    ([#stop, #stop], [(#stopped, 0, 0), (#shutdown, 1, 0)]),
+    ([#stop 0, #ok], [(#stopped, 0, 0), (#shutdown, 2, 0)]),
+    ([#stop 0, #gap], [(#stopped, 0, 0), (#stopped, 0, 0)]),
+    ([#stop 0, #error], [(#stopped, 0, 0), (#stopped, 0, 0)]),
+    ([#stop 0, #stop 0], [(#stopped, 0, 0), (#shutdown, 1, 0)]),
   ];
   for (t in tests.vals()) {
     let (responses, statuses) = t;
@@ -408,22 +409,22 @@ do {
     ([#ok, #ok], [(#ready, 2, 2), (#ready, 2, 2)]),
     ([#ok, #gap], [(#paused, 0, 1), (#ready, 1, 1)]),
     ([#ok, #error], [(#paused, 0, 1), (#ready, 1, 1)]),
-    ([#ok, #stop], [(#stopped, 1, 1), (#stopped, 1, 1)]),
+    ([#ok, #stop 0], [(#stopped, 1, 1), (#stopped, 1, 1)]),
 
     ([#gap, #ok], [(#ready, 2, 2), (#shutdown, 2, 0)]),
     ([#gap, #gap], [(#paused, 0, 1), (#shutdown, 0, 0)]),
     ([#gap, #error], [(#paused, 0, 1), (#shutdown, 0, 0)]),
-    ([#gap, #stop], [(#stopped, 1, 1), (#shutdown, 1, 0)]),
+    ([#gap, #stop 0], [(#stopped, 1, 1), (#shutdown, 1, 0)]),
 
     ([#error, #ok], [(#ready, 2, 2), (#shutdown, 2, 0)]),
     ([#error, #gap], [(#paused, 0, 1), (#ready, 0, 0)]),
     ([#error, #error], [(#paused, 0, 1), (#ready, 0, 0)]),
-    ([#error, #stop], [(#stopped, 1, 1), (#shutdown, 1, 0)]),
+    ([#error, #stop 0], [(#stopped, 1, 1), (#shutdown, 1, 0)]),
 
-    ([#stop, #ok], [(#ready, 2, 2), (#shutdown, 2, 0)]),
-    ([#stop, #gap], [(#paused, 0, 1), (#stopped, 0, 0)]),
-    ([#stop, #error], [(#paused, 0, 1), (#stopped, 0, 0)]),
-    ([#stop, #stop], [(#stopped, 1, 1), (#shutdown, 1, 0)]),
+    ([#stop 0, #ok], [(#ready, 2, 2), (#shutdown, 2, 0)]),
+    ([#stop 0, #gap], [(#paused, 0, 1), (#stopped, 0, 0)]),
+    ([#stop 0, #error], [(#paused, 0, 1), (#stopped, 0, 0)]),
+    ([#stop 0, #stop 0], [(#stopped, 1, 1), (#shutdown, 1, 0)]),
   ];
   for (t in tests.vals()) {
     let (responses, statuses) = t;

--- a/test/sender.concurrent.test.mo
+++ b/test/sender.concurrent.test.mo
@@ -55,7 +55,7 @@ class Sender(n : Nat) {
 
   let sender = StreamSender.StreamSender<Text, ?Text>(
     sendChunkMessage,
-    Base.create(1)
+    Base.create(1),
   );
   sender.setKeepAlive(?(1, func() = time));
 
@@ -148,7 +148,7 @@ func allCases(n : Nat) : async () {
   func getResponses(a_ : Nat32, b_ : Nat32, c : Nat) : ([(ChunkResponse, ChunkRequest)], Nat) {
     var time : Int = 0;
     let r = StreamReceiver.StreamReceiver<()>(
-      func(pos : Nat, item : ()) = (),
+      func(pos : Nat, item : ()) = true,
       ?(1, func() = time),
     );
     var x = 0;
@@ -261,7 +261,7 @@ do {
   let n = 100;
   let p = random_permutation(n);
   let s = Sender(n);
-  let r = StreamReceiver.StreamReceiver<()>(func(pos : Nat, item : ()) = (), null);
+  let r = StreamReceiver.StreamReceiver<()>(func(pos : Nat, item : ()) = true, null);
 
   s.setMaxN(n + 1);
   let chunk = Array.tabulate<Chunk>(n, func(i) = Chunk());

--- a/test/sender.test.mo
+++ b/test/sender.test.mo
@@ -70,7 +70,7 @@ do {
 // #stop response
 do {
   func send(message : Types.ChunkMessage<?Text>) : async* Types.ControlMessage {
-    #stop;
+    #stop 0;
   };
 
   let sender = StreamSender.StreamSender<Text, ?Text>(


### PR DESCRIPTION
Allow processing of partial batches before stopping.

* the itemCallback can stop a stream
* maxLength can stop a stream

Both can lead to a partially processed stream. The sender will now at which position the stream stopped.

TODO: test for stop by itemCallback, test for stop by maxLength