### PR TITLE
Example upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Streams changelog
 
+## 0.0.6
+
+* Demo persistence in promtracker example
+
 ## 0.0.5
 
 * Use environment variables in examples

--- a/README.md
+++ b/README.md
@@ -120,18 +120,22 @@ import Stream "../../../src/StreamSender";
 import Prim "mo:prim";
 
 persistent actor Alice {
-  // Read Bob's canister ID from environment variable
-  transient let bob = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:bob")) {
-      case (?id) id;
-      case _ Prim.trap("Environment variable 'bob' not set");
-    };
+  // Read Bob's canister id once from an environment variable.
+  //
+  // Note: We don't allow the receiver to change later because that
+  // would risk corrupting the stream state. We would create a new
+  // stream instead if we have a new receiver.
+  let bob : Text = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:bob")) {
+    case (?id) id;
+    case _ Prim.trap("Environment variable 'PUBLIC_CANISTER_ID:bob' not set");
+  };
 
   // Substitute your item type here
   type Item = Nat;
 
   // The endpoint (update method) on Bob's side must have this type:
   type RecvFunc = shared Stream.ChunkMessage<Item> -> async Stream.ControlMessage;
-  
+
   // The endpoint (update method) on Bob's side is called "receive" in this example.
   // Hence, this is the actor supertype for Bob that we use:
   type ReceiverAPI = actor { receive : RecvFunc };
@@ -139,20 +143,20 @@ persistent actor Alice {
   // This is Bob, the receiving actor whose Principal was supplied in the init argument:
   transient let B : ReceiverAPI = actor (bob);
 
-  // This is our `sendFunc` which is simply a wrapper around Bob's `receive` method.  
-  // It is possible to wrap custom code around calling `B.receive` but we must not tamper  
+  // This is our `sendFunc` which is simply a wrapper around Bob's `receive` method.
+  // It is possible to wrap custom code around calling `B.receive` but we must not tamper
   // with the response and we must not trap.
   transient let send_ = func(x : Stream.ChunkMessage<Item>) : async* Stream.ControlMessage {
-    await B.receive(x)
+    await B.receive(x);
   };
 
-  // This is our `counterCreator`. 
+  // This is our `counterCreator`.
 
   // A class with a single `accept` method which returns `null` when a batch is full.
   // In this example we simply count the number of items and allow at most 3 items in a batch.
   // We also do not transform the items, i.e. the type of items in the queue is identical to
   // the type of items in the batch.
-  
+
   class counter_() {
     var sum = 0;
     let maxLength = 3;
@@ -174,12 +178,13 @@ persistent actor Alice {
       i += 1;
     };
   };
-  
+
   // This function shows how we trigger a chunk to formed and sent with `sendChunk`.
   public shared func batch() : async () {
     await* sender.sendChunk();
   };
 };
+
 ```
 
 ### Example of receiver
@@ -193,11 +198,15 @@ import Stream "../../../src/StreamReceiver";
 import Prim "mo:prim";
 
 persistent actor Bob {
-  // Read allowed caller canister principal from environment variable
-  transient let allowedCaller = Principal.fromText(
+  // Read Alice's principal once from an environment variable.
+  //
+  // Note: We don't allow the sender to change later because that
+  // would risk corrupting the stream state. We would create a new
+  // stream instead if we have a new sender.
+  let sender = Principal.fromText(
     switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:alice")) {
       case (?id) id;
-      case _ Prim.trap("Environment variable 'alice' not set");
+      case _ Prim.trap("Environment variable 'PUBLIC_CANISTER_ID:alice' not set");
     }
   );
 
@@ -225,7 +234,7 @@ persistent actor Bob {
   // with the response and we must not trap.
   public shared (msg) func receive(m : Stream.ChunkMessage<Item>) : async Stream.ControlMessage {
     // Make sure only Alice can call this method
-    if (msg.caller != allowedCaller) throw Error.reject("not authorized");
+    if (msg.caller != sender) throw Error.reject("not authorized");
     receiver_.onChunk(m);
   };
 
@@ -255,7 +264,7 @@ mops test
 ### Executable examples
 
 The `examples/` directory contains executable examples.
-To run them locally follow the instructions here: [examples/README.md](examples/README.md).
+For an overview and how to run them locally see: [examples/README.md](examples/README.md).
 
 #### Minimal
 
@@ -264,13 +273,23 @@ Minimal code required to get a sender and a receiver talking to each other.
 #### Main
 
 Compared to the example above this demonstrates:
+
 * how a more sophisticated counter for batch preparation can look like
 * how queue type can differ from sending type
 * how to send chunks from heartbeat
+* how to persist the stream across canister upgrades
 
 #### Promtracker
 
-Example to show using trackers along with streams.
+Compared to the main example this demonstrates:
+
+* how to use a Tracker connected to a stream
+* how to persist the metrics across canister upgrades
+
+You can watch the metrics from a browser at a URL like this:
+http://txyno-ch777-77776-aaaaq-cai.raw.localhost:8000/metrics
+where `txyno-ch777-77776-aaaaq-cai` is replaced by the canister id
+that is shown during `icp deploy`.
 
 ## Design
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,3 +26,28 @@ icp deploy
 sh run.sh
 icp network stop
 ```
+
+## Minimal
+
+Minimal code required to get a sender and a receiver talking to each other.
+
+## Main
+
+Compared to the example above this demonstrates:
+
+* how a more sophisticated counter for batch preparation can look like
+* how queue type can differ from sending type
+* how to send chunks from heartbeat
+* how to persist the stream across canister upgrades
+
+## Promtracker
+
+Compared to the main example this demonstrates:
+
+* how to use a Tracker connected to a stream
+* how to persist the metrics across canister upgrades
+
+You can watch the metrics from a browser at a URL like this:
+http://txyno-ch777-77776-aaaaq-cai.raw.localhost:8000/metrics
+where `txyno-ch777-77776-aaaaq-cai` is replaced by the canister id
+that is shown during `icp deploy`.

--- a/examples/main/run.sh
+++ b/examples/main/run.sh
@@ -13,3 +13,11 @@ icp canister call sender add '("mno")'
 icp canister call receiver lastReceived '()'
 icp canister call sender add '("pqr")'
 icp canister call receiver lastReceived '()'
+
+icp deploy
+
+# stream still functioning after canister upgrade
+icp canister call sender add '("abc")'
+icp canister call receiver lastReceived '()'
+icp canister call sender add '("def")'
+icp canister call receiver lastReceived '()'

--- a/examples/minimal/icp.yaml
+++ b/examples/minimal/icp.yaml
@@ -7,6 +7,7 @@ canisters:
       configuration:
         main: "src/alice.mo"
         args: ""
+        shrink: false
 
   - name: bob
     recipe:
@@ -14,3 +15,4 @@ canisters:
       configuration:
         main: "src/bob.mo"
         args: ""
+        shrink: false

--- a/examples/minimal/src/alice.mo
+++ b/examples/minimal/src/alice.mo
@@ -2,18 +2,22 @@ import Stream "../../../src/StreamSender";
 import Prim "mo:prim";
 
 persistent actor Alice {
-  // Read Bob's canister ID from environment variable
-  transient let bob = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:bob")) {
-      case (?id) id;
-      case _ Prim.trap("Environment variable 'PUBLIC_CANISTER_ID:bob' not set");
-    };
+  // Read Bob's canister id once from an environment variable.
+  //
+  // Note: We don't allow the receiver to change later because that
+  // would risk corrupting the stream state. We would create a new
+  // stream instead if we have a new receiver.
+  let bob : Text = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:bob")) {
+    case (?id) id;
+    case _ Prim.trap("Environment variable 'PUBLIC_CANISTER_ID:bob' not set");
+  };
 
   // Substitute your item type here
   type Item = Nat;
 
   // The endpoint (update method) on Bob's side must have this type:
   type RecvFunc = shared Stream.ChunkMessage<Item> -> async Stream.ControlMessage;
-  
+
   // The endpoint (update method) on Bob's side is called "receive" in this example.
   // Hence, this is the actor supertype for Bob that we use:
   type ReceiverAPI = actor { receive : RecvFunc };
@@ -21,20 +25,20 @@ persistent actor Alice {
   // This is Bob, the receiving actor whose Principal was supplied in the init argument:
   transient let B : ReceiverAPI = actor (bob);
 
-  // This is our `sendFunc` which is simply a wrapper around Bob's `receive` method.  
-  // It is possible to wrap custom code around calling `B.receive` but we must not tamper  
+  // This is our `sendFunc` which is simply a wrapper around Bob's `receive` method.
+  // It is possible to wrap custom code around calling `B.receive` but we must not tamper
   // with the response and we must not trap.
   transient let send_ = func(x : Stream.ChunkMessage<Item>) : async* Stream.ControlMessage {
-    await B.receive(x)
+    await B.receive(x);
   };
 
-  // This is our `counterCreator`. 
+  // This is our `counterCreator`.
 
   // A class with a single `accept` method which returns `null` when a batch is full.
   // In this example we simply count the number of items and allow at most 3 items in a batch.
   // We also do not transform the items, i.e. the type of items in the queue is identical to
   // the type of items in the batch.
-  
+
   class counter_() {
     var sum = 0;
     let maxLength = 3;
@@ -56,7 +60,7 @@ persistent actor Alice {
       i += 1;
     };
   };
-  
+
   // This function shows how we trigger a chunk to formed and sent with `sendChunk`.
   public shared func batch() : async () {
     await* sender.sendChunk();

--- a/examples/minimal/src/bob.mo
+++ b/examples/minimal/src/bob.mo
@@ -4,7 +4,7 @@ import Stream "../../../src/StreamReceiver";
 import Prim "mo:prim";
 
 persistent actor Bob {
-  // Read sender principal once from an environment variable.
+  // Read Alice's principal once from an environment variable.
   //
   // Note: We don't allow the sender to change later because that
   // would risk corrupting the stream state. We would create a new

--- a/examples/promtracker/run.sh
+++ b/examples/promtracker/run.sh
@@ -14,4 +14,10 @@ icp canister call receiver lastReceived '()'
 icp canister call sender add '("pqr")'
 icp canister call receiver lastReceived '()'
 
-#icp canister call sender http_request '(record { method = "GET"; url = "/metrics"; headers = vec {}; body = blob "" })'
+icp deploy
+
+# stream and metrics still functioning after canister upgrade
+icp canister call sender add '("abc")'
+icp canister call receiver lastReceived '()'
+icp canister call sender add '("def")'
+icp canister call receiver lastReceived '()'

--- a/examples/promtracker/run.sh
+++ b/examples/promtracker/run.sh
@@ -13,3 +13,5 @@ icp canister call sender add '("mno")'
 icp canister call receiver lastReceived '()'
 icp canister call sender add '("pqr")'
 icp canister call receiver lastReceived '()'
+
+#icp canister call sender http_request '(record { method = "GET"; url = "/metrics"; headers = vec {}; body = blob "" })'

--- a/examples/promtracker/src/receiver.mo
+++ b/examples/promtracker/src/receiver.mo
@@ -28,23 +28,23 @@ persistent actor Receiver {
 
   transient let receiver = Stream.StreamReceiver<?Text>(
     func(_ : Nat, item : ?Text) : Bool { store := item; true },
-    ?(10 ** 15, Time.now),
+    ?(10 ** 12, Time.now),
   );
 
   transient let metrics = PT.PromTracker(PT.canisterLabel(Receiver), 65);
-  transient let tracker = Tracker.Receiver(metrics, "", false);
+  transient let tracker = Tracker.Receiver(metrics, "", true);
   tracker.init(receiver);
 
   // Persist stream state and metrics across upgrades
   var streamData = receiver.share();
   var ptData = metrics.share();
-  system func postupgrade() {
-    receiver.unshare(streamData);
-    metrics.unshare(ptData);
-  };
   system func preupgrade() {
     streamData := receiver.share();
     ptData := metrics.share();
+  };
+  system func postupgrade() {
+    receiver.unshare(streamData);
+    metrics.unshare(ptData);
   };
 
   public shared (msg) func receive(c : ChunkMessage) : async ControlMessage {

--- a/examples/promtracker/src/sender.mo
+++ b/examples/promtracker/src/sender.mo
@@ -43,7 +43,7 @@ persistent actor Sender {
     func(x : ChunkMessage) : async* ControlMessage { await receiver.receive(x) },
     counter,
   );
-  sender.setKeepAlive(?(10 ** 15, Time.now));
+  sender.setKeepAlive(?(10 ** 11, Time.now));
 
   transient let metrics = PT.PromTracker(PT.canisterLabel(Sender), 65);
   transient let tracker = Tracker.Sender(metrics, "", true);

--- a/examples/promtracker/src/sender.mo
+++ b/examples/promtracker/src/sender.mo
@@ -7,16 +7,20 @@ import Prim "mo:prim";
 import PT "mo:promtracker";
 
 persistent actor Sender {
-  // Read Receiver's canister ID from environment variable
-  transient let receiverId = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:receiver")) {
-      case (?id) id;
-      case _ Prim.trap("Environment variable 'PUBLIC_CANISTER_ID:receiver' not set");
-    };
+  // Read receiver canister id once from an environment variable.
+  //
+  // Note: We don't allow the receiver to change later because that
+  // would risk corrupting the stream state. We would create a new
+  // stream instead if we have a new receiver.
+  let receiverId : Text = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:receiver")) {
+    case (?id) id;
+    case _ Prim.trap("Environment variable 'PUBLIC_CANISTER_ID:receiver' not set");
+  };
 
   type ControlMessage = Stream.ControlMessage;
   type ChunkMessage = Stream.ChunkMessage<?Text>;
 
-  transient let receiver = actor (receiverId) : actor {
+  let receiver = actor (receiverId) : actor {
     receive : (message : ChunkMessage) -> async ControlMessage;
   };
 
@@ -35,17 +39,27 @@ persistent actor Sender {
     };
   };
 
-  transient let metrics = PT.PromTracker(PT.canisterLabel(Sender), 65);
-  transient let tracker = Tracker.Sender(metrics, "", true);
-
   transient let sender = Stream.StreamSender<Text, ?Text>(
     func(x : ChunkMessage) : async* ControlMessage { await receiver.receive(x) },
     counter,
   );
-
   sender.setKeepAlive(?(10 ** 15, Time.now));
 
+  transient let metrics = PT.PromTracker(PT.canisterLabel(Sender), 65);
+  transient let tracker = Tracker.Sender(metrics, "", true);
   tracker.init(sender);
+
+  // Persist stream state and metrics across upgrades
+  var streamData = sender.share();
+  var ptData = metrics.share();
+  system func postupgrade() {
+    sender.unshare(streamData);
+    metrics.unshare(ptData);
+  };
+  system func preupgrade() {
+    streamData := sender.share();
+    ptData := metrics.share();
+  };
 
   public shared func add(text : Text) : async () {
     Result.assertOk(sender.push(text));

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream"
-version = "0.0.5"
+version = "0.0.6"
 description = "Stream sender and receiver libraries"
 repository = "https://github.com/research-ag/stream"
 keywords = [ "sender", "receiver", "batch", "concurrent", "order" ]

--- a/src/StreamReceiver.mo
+++ b/src/StreamReceiver.mo
@@ -18,13 +18,22 @@ module {
   };
 
   /// StreamReceiver
-  /// * receives chunk by `onChunk` call
-  /// * validates `start` position in ChunkMessage (must match internal `length` variable)
+  ///
+  /// * receives chunk by `onChunk` call,
+  /// * validates `start` position in ChunkMessage (must match internal `length` variable),
   /// * calls `itemCallback` for each item of the chunk.
   ///
   /// Constructor arguments:
-  /// * `itemCallback` function
-  /// * `timeoutArg` defines the maximum waiting time between onChunk calls (null = infinite)
+  ///
+  /// * `itemCallback`: function which is going to be called on each received item.
+  /// * `timeoutArg`: the maximum waiting time between onChunk calls (null = infinite)
+  ///
+  /// `timeoutArg` is an optional pair of:
+  ///
+  ///   * a duration after which `StreamReceiver` times out the stream if it has not received any chunks,
+  ///   * a function returning the current time
+  ///
+  /// The duration and the function can use any time unit, as long as they use the same unit.
   public class StreamReceiver<T>(
     itemCallback : (pos : Nat, item : T) -> Bool,
     timeoutArg : ?(Nat, () -> Int),

--- a/src/StreamSender.mo
+++ b/src/StreamSender.mo
@@ -48,6 +48,7 @@ module {
   /// Stream sender receiving items of type `Q` with `push` function and sending them with `sendFunc` callback when calling `sendChunk`.
   ///
   /// Arguments:
+  ///
   /// * `sendFunc` typically should implement sending chunk to the receiver canister.
   /// * `counterCreator` is used to create a chunk out of pushed items.
   /// `accept` function is called sequentially on items which are added to the chunk, until receiving `null`.
@@ -297,8 +298,9 @@ module {
     public func windowSize() : Nat = settings.windowSize;
 
     /// Get `keepAlive` setting.
-    /// `keepAlive` is pair of period in seconds after which `StreamSender` should send ping chunk in case if there is no items to send and current time function.
-    /// Default value means not to ping.
+    /// This is the time period after which `StreamSender` sends a "ping chunk" in case there are no other items to send.
+    /// See `setKeepAlive` for more details.
+    /// A `null` value means the `StreamSender` does not ping.
     public func keepAliveTime() : ?Nat = Option.map<(Nat, () -> Int), Nat>(settings.keepAlive, func(x) = x.0);
 
     /// Update max queue size.
@@ -314,8 +316,14 @@ module {
     public func setWindowSize(n : Nat) = settings.windowSize := n;
 
     /// Update max interval between stream calls.
-    /// `keepAlive` is pair of period in seconds after which `StreamSender` should send ping chunk in case if there is no items to send and current time function.
-    /// Default value means not to ping.
+    /// `keepAlive` is an optional pair of:
+    ///
+    ///   * a duration after which `StreamSender` should send a "ping chunk" in case there are no other items to send
+    ///   * a function returning the current time
+    ///
+    /// The duration and the function can use any time unit, as long as they use the same unit.
+    ///
+    /// The value `null` means not to ping.
     public func setKeepAlive(seconds : ?(Nat, () -> Int)) {
       settings.keepAlive := seconds;
     };

--- a/src/Tracker.mo
+++ b/src/Tracker.mo
@@ -30,8 +30,9 @@ module {
   /// the metrics in the PromTracker.
   ///
   /// Further constructor arguments are:
-  ///   labels : additional labels given to all metrics that are added to the PromTracker.
-  ///   stable_ : whether PromTracker persists the metrics across canister upgrades or not.
+  ///
+  /// * `labels` : additional labels given to all metrics that are added to the PromTracker.
+  /// * `stable_` : whether PromTracker persists the metrics across canister upgrades or not.
   ///
   /// If you want to connect more than one Receiver to the same PromTracker then
   /// create multiple Receiver tracker instances, one for each Receiver instance.


### PR DESCRIPTION
* Show persistence of streams
* Show persistence of metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream state now persists across canister upgrades in Main and Promtracker examples.
  * Example run scripts perform post-upgrade verification to confirm streaming and metrics remain functional.

* **Documentation**
  * Added detailed example scenarios (Minimal, Main, Promtracker), clarified README examples and error messages, and included a metrics URL in Promtracker.
  * Expanded API docs for stream sender/receiver and tracker; formatting and code-example fixes.

* **Chores**
  * Package version bumped to 0.0.6 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->